### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   prepare:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
Potential fix for [https://github.com/samlowe106/PaperScraper/security/code-scanning/2](https://github.com/samlowe106/PaperScraper/security/code-scanning/2)

Add an explicit `permissions` block to the `prepare` job in `.github/workflows/tests.yml`, since that is the job currently missing it and triggering the alert.  
Best minimal fix without changing behavior: grant only `contents: read` for `prepare`, because it uses `actions/checkout` and a shell step that reads local files and writes job outputs; it does not need write scopes.

Edit region: under `jobs.prepare` (around lines 10–12), insert:

```yml
permissions:
  contents: read
```

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
